### PR TITLE
Dont do validate when validator="[]"

### DIFF
--- a/dist/angular-validator.js
+++ b/dist/angular-validator.js
@@ -129,7 +129,7 @@
               rules.push(rule);
               return;
             }
-            match = value.match(/^\[(.*)\]$/);
+            match = value.match(/^\[(.+)\]$/);
             if (match) {
               ruleNames = match[1].split(',');
               _results = [];

--- a/src/directive.coffee
+++ b/src/directive.coffee
@@ -101,7 +101,7 @@ angular.module 'validator.directive', ['validator.provider']
                 return
 
             # validat by rules
-            match = value.match /^\[(.*)\]$/
+            match = value.match /^\[(.+)\]$/
             if match
                 ruleNames = match[1].split ','
                 for name in ruleNames


### PR DESCRIPTION
When using `validator="[]"` will cause this error https://github.com/kelp404/angular-validator/issues/9

![screen shot 2014-05-22 at 5 32 31 pm](https://cloud.githubusercontent.com/assets/2560096/3052000/202b7a34-e194-11e3-932f-4a5289ea4c94.png)
