### PR TITLE
Fix validator="[]" to pass validation

### DIFF
--- a/dist/angular-validator.js
+++ b/dist/angular-validator.js
@@ -129,6 +129,15 @@
               rules.push(rule);
               return;
             }
+            match = value.match(/^\[\]$/);
+            if (match) {
+              rule = $validator.convertRule('dynamic', {
+                validator: /.*/,
+                invoke: attrs.validatorInvoke
+              });
+              rules.push(rule);
+              return;
+            }
             match = value.match(/^\[(.+)\]$/);
             if (match) {
               ruleNames = match[1].split(',');

--- a/src/directive.coffee
+++ b/src/directive.coffee
@@ -100,6 +100,15 @@ angular.module 'validator.directive', ['validator.provider']
                 rules.push rule
                 return
 
+            # validat by []
+            match = value.match /^\[\]$/
+            if match
+                rule = $validator.convertRule 'dynamic',
+                    validator: /.*/
+                    invoke: attrs.validatorInvoke
+                rules.push rule
+                return
+
             # validat by rules
             match = value.match /^\[(.+)\]$/
             if match


### PR DESCRIPTION
In last commit, when we use `validator="[]"`, angular-validator still going through the validation but error

I didn't get any success console 

![screen shot 2014-05-27 at 4 26 06 pm](https://cloud.githubusercontent.com/assets/2560096/3089117/e2af1518-e57a-11e3-95b8-7764e098ae6c.png)

I suppose that having `validator="[]"` input still need to do the validation procedure, so I add this.

Else, it can just ignore the procedure when having `validator="[]"`
