### PR TITLE
fixed error when rule is null

### DIFF
--- a/dist/angular-validator.js
+++ b/dist/angular-validator.js
@@ -138,7 +138,7 @@
               for (_i = 0, _len = ruleNames.length; _i < _len; _i++) {
                 name = ruleNames[_i];
                 rule = $validator.getRule(name.replace(/^\s+|\s+$/g, ''));
-                if (typeof rule.init === "function") {
+                if (rule && typeof rule.init === "function") {
                   rule.init(scope, element, attrs, $injector);
                 }
                 if (rule) {


### PR DESCRIPTION
$validator.getRule can return null and without this check this error would be raised:
    TypeError: Cannot read property 'init' of null
    at http://localhost:9000/bower_components/angular-validator/dist/angular-validator.js:141:32