### PR TITLE
fixed raising error when the rule is null

### DIFF
--- a/src/directive.coffee
+++ b/src/directive.coffee
@@ -109,7 +109,7 @@ angular.module 'validator.directive', ['validator.provider']
                 for name in ruleNames
                     # stupid browser has no .trim()
                     rule = $validator.getRule name.replace(/^\s+|\s+$/g, '')
-                    rule.init? scope, element, attrs, $injector
+                    rule? && rule.init? scope, element, attrs, $injector
                     rules.push rule if rule
 
         attrs.$observe 'validatorError', (value) ->


### PR DESCRIPTION
$validator.getRule can return null and without this check this error would be raised:
TypeError: Cannot read property 'init' of null
at http://localhost:9000/bower_components/angular-validator/dist/angular-validator.js:141:32