### PR TITLE
Fix display error message when using an error function.

### DIFF
--- a/dist/angular-validator.js
+++ b/dist/angular-validator.js
@@ -311,13 +311,9 @@
       @param error: error messate (string) or function(value, scope, element, attrs, $injector)
       @return: function(value, scope, element, attrs, $injector)
        */
-      var errorMessage;
-      if (typeof error === 'function') {
-        return error;
-      }
-      errorMessage = error.constructor === String ? error : '';
       return function(value, scope, element, attrs) {
         var $label, label, parent, _i, _len, _ref, _results;
+	var errorMessage = (typeof error === 'function') ? error(value, scope, element, attrs) : (error.constructor === String ? error : '');
         parent = $(element).parent();
         _results = [];
         while (parent.length !== 0) {


### PR DESCRIPTION
When using an error function to display a custom error message, the message is never displayed.